### PR TITLE
Allow token-based authentication

### DIFF
--- a/grafana_dashboard_manager/__main__.py
+++ b/grafana_dashboard_manager/__main__.py
@@ -45,16 +45,16 @@ app.add_typer(
 def main(
     host: str = typer.Option(..., help="Grafana host including 'http(s)://'"),
     username: str = typer.Option("admin", help="Grafana admin login username"),
-    password: str = typer.Option(..., help="Grafana admin login password"),
+    password: str = typer.Option(None, help="Grafana admin login password"),
+    token: str = typer.Option(None, help="Grafana API token with admin privileges"),
     verbose: bool = typer.Option(False, help="Output debug level logging"),
 ):
     """
     Manage Beam deployed Grafana instances.
     """
     grafana.host = host
-    grafana.username = username
-    grafana.password = password
-    grafana.api = RestApiBasicAuth(grafana.host, grafana.username, grafana.password)
+    grafana.credentials = token if token else (username, password)
+    grafana.api = RestApiBasicAuth(grafana.host, grafana.credentials)
 
     if verbose:
         logging.getLogger().setLevel("DEBUG")

--- a/grafana_dashboard_manager/api.py
+++ b/grafana_dashboard_manager/api.py
@@ -11,15 +11,30 @@ Wrapper interface for the REST API to grafana
 
 import json
 import logging
-import sys
 from dataclasses import dataclass
 from typing import Dict
 
 import requests
+import six
 
 logger = logging.getLogger()
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+class TokenAuth(requests.auth.AuthBase):
+    """
+    Authentication using a Grafana API token.
+    """
+
+    def __init__(self, token: str):
+        self.token = token
+
+    def __call__(self, request: requests.models.Request):
+        request.headers.update({
+            "Authorization": f"Bearer {self.token}"
+        })
+        return request
 
 
 class RestApiBasicAuth:
@@ -27,34 +42,45 @@ class RestApiBasicAuth:
     HTTP REST calls with status code checking and common auth/headers
     """
 
-    def __init__(self, host: str = "", username: str = "", password: str = "") -> None:
+    def __init__(self, host: str = "", credentials = None) -> None:
         self.host = host
-        self.username = username
-        self.password = password
+        self.session = requests.Session()
+        self.session.headers = {
+            "Accept": "application/json; charset=UTF-8"
+        }
+        if credentials is None:
+            pass
+        elif isinstance(credentials, six.string_types):
+            self.session.auth = TokenAuth(credentials)
+        else:
+            self.session.auth = requests.auth.HTTPBasicAuth(*credentials)
 
     def get(self, resource: str) -> Dict:
         """HTTP GET"""
-        response = requests.get(f"{self.host}/api/{resource}", auth=(self.username, self.password))
+        response = self.session.request("GET", f"{self.host}/api/{resource}")
         return self._check_response(response.status_code, json.loads(response.text))
 
     def post(self, resource: str, body: dict) -> Dict:
         """HTTP POST"""
-        response = requests.post(
+        response = self.session.request(
+            "POST",
             f"{self.host}/api/{resource}",
-            auth=(self.username, self.password),
-            json=body,
-            headers={"Content-type": "application/json"},
+            json=body
         )
         return self._check_response(response.status_code, json.loads(response.text))
 
     def put(self, resource: str, body: dict) -> Dict:
         """HTTP PUT"""
-        response = requests.put(f"{self.host}/api/{resource}", auth=(self.username, self.password), data=body)
+        response = self.session.request(
+            "PUT",
+            f"{self.host}/api/{resource}",
+            data=body
+        )
         return self._check_response(response.status_code, json.loads(response.text))
 
     def delete(self, resource: str) -> Dict:
         """HTTP DELETE"""
-        response = requests.delete(f"{self.host}/api/{resource}", auth=(self.username, self.password))
+        response = self.session.request("DELETE", f"{self.host}/api/{resource}")
         return self._check_response(response.status_code, json.loads(response.text))
 
     @staticmethod
@@ -71,8 +97,7 @@ class GrafanaAPI:
     """Container for API config and the api access interface"""
 
     host: str = ""
-    username: str = ""
-    password: str = ""
+    credentials = None
     api: RestApiBasicAuth = RestApiBasicAuth()
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -287,6 +287,14 @@ typing-extensions = {version = ">=3.7.4,<5.0", markers = "python_version < \"3.8
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -371,7 +379,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9a97d292b860ff468543816d5b0757ed1721efadad504e5c61a5efb2b689f1c8"
+content-hash = "9b76e15796b87d458fef8bc06e8a3b2047cfa2e76a0cbf989bea70acb846e7d1"
 
 [metadata.files]
 astroid = [
@@ -504,6 +512,10 @@ requests = [
 rich = [
     {file = "rich-10.16.2-py3-none-any.whl", hash = "sha256:c59d73bd804c90f747c8d7b1d023b88f2a9ac2454224a4aeaf959b21eeb42d03"},
     {file = "rich-10.16.2.tar.gz", hash = "sha256:720974689960e06c2efdb54327f8bf0cdbdf4eae4ad73b6c94213cad405c371b"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python = "^3.7"
 typer = "^0.4.0"
 requests = "^2.26.0"
 rich = "^10.14.0"
+six = "^1.11.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
This change should provide users an option to use a Grafana API token. I also make use of `requests.Session` to make sure Grafana session cookie persists across requests and for connection pooling; should be helpful when you got a lot of dashboards to download.