### PR TITLE
Update documentation and HTTP error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ The intended workflow is:
 
 ### Install via _[pip](https://pypi.org/project/pip/)_:
 
-```bash
+```shell
 pip install grafana-dashboard-manager
 ```
 
 ### Install from source - requires _[Poetry](https://python-poetry.org/)_ on your system:
 
-```bash
+```shell
 cd /path/to/grafana-dashboard-manager
 poetry install
 ```
@@ -50,7 +50,7 @@ For more help, see the full help text with `poetry run grafana-dashboard-manager
 
 ### Download dashboards from web to solution-data using the Grafana admin user
 
-```bash
+```shell
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
     --username admin_username --password admin_password \
@@ -60,7 +60,7 @@ poetry run grafana-dashboard-manager \
 
 ### Download dashboards from web to solution-data using a Grafana admin API Key
 
-```bash
+```shell
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
     --token admin_api_key \
@@ -70,7 +70,7 @@ poetry run grafana-dashboard-manager \
 
 ### Upload dashboards from solution-data to web using the Grafana admin user
 
-```bash
+```shell
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
     --username admin_username --password admin_password \
@@ -80,7 +80,7 @@ poetry run grafana-dashboard-manager \
 
 ### Upload dashboards from solution-data to web using a Grafana admin API Key
 
-```bash
+```shell
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
     --token admin_api_key \

--- a/README.md
+++ b/README.md
@@ -2,80 +2,97 @@
 
 ![CodeQL](https://github.com/Beam-Connectivity/grafana-dashboard-manager/actions/workflows/codeql-analysis.yml/badge.svg)
 
+## Introduction
 
-A simple cli utility for importing or exporting dashboard json definitions using the Grafana HTTP API.
+A simple CLI utility for importing or exporting dashboard JSON definitions using the Grafana HTTP API.
 
-This may be useful for:
+This can be used for:
 
-- Backing up your dashboards that already exist within your Grafana instance, e.g. if you are migrating from the internal sqlite database to MySQL.
-- Updating dashboard files for your Infrastructure-as-Code, for use with Grafana dashboard provisioning.
+- Backing up your dashboards that already exist within your Grafana instance, e.g. if you are migrating from the internal SQLite database to MySQL.
+- Updating dashboard files for your Infrastructure-as-Code for use with [Grafana dashboard provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards).
 - Making tweaks to dashboard JSON files directly and updating Grafana with one command.
 
-Notable features:
+### Features
 
 - Mirrors the folder structure between a local set of dashboards and Grafana, creating folders where necessary.
-- Ensures links to dashboards folders in a `dashlist` Panel are consistent with the Folder IDs - useful for deploying one set of dashboards across mulitple Grafana instances, e.g. for dev, test, prod environments.
+- Ensures links to dashboards folders in a `dashlist` Panel are consistent with the Folder IDs - useful for deploying one set of dashboards across multiple Grafana instances, for instance across environments.
 
 ### Workflow
 
-The intended development process is:
+The intended workflow is:
 
-1. Develop existing dashboard, or create a new one and save it in the web UI.
-2. Ensure the dashboard is in the desired folder.
-3. Use `grafana-dashboard-manager` to extract the new dashboards and save them to a local directory.
-4. Dashboards can be created/updated from the local directory back into Grafana.
+1. Create a dashboard and save it in the desired folder from within the Grafana web GUI
+2. Use `grafana-dashboard-manager` to extract the new dashboards and save them to a local directory or version control system.
+3. Dashboards can be created or updated from the local store and uploaded back into Grafana.
 
-# Usage
+## Installation
 
-#### Installation
-
-Dependencies are managed with poetry.
-
-Install from pypi:
+### Install via _[pip](https://pypi.org/project/pip/)_:
 
 ```bash
-$ pip install grafana-dashboard-manager
+pip install grafana-dashboard-manager
 ```
 
-Install from source (requires [poetry](https://python-poetry.org/) on your system)
+### Install from source - requires _[Poetry](https://python-poetry.org/)_ on your system:
 
 ```bash
-$ cd /path/to/grafana-dashboard-manager
-$ poetry install
+cd /path/to/grafana-dashboard-manager
+poetry install
 ```
 
-Note that the admin login user and password are required, and its selected organization is correct.
+## Usage
 
-See the full help text with `poetry run grafana-dashboard-manager --help`
+### Credentials
 
-### Download dashboards from web to solution-data
+It is important to note that the **admin** login username and password are required, and its selected organization must be correct, if you are accessing the API using `--username` and `--password`. Alternatively, the API Key must have **admin** permissions if you are accessing the API using `--token`.
+
+For more help, see the full help text with `poetry run grafana-dashboard-manager --help`.
+
+### Download dashboards from web to solution-data using the Grafana admin user
 
 ```bash
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
-    --username admin --password mypassword \
+    --username admin_username --password admin_password \
     download all \
     --destination-dir /path/to/dashboards/
 ```
 
-### Upload dashboards from solution-data to web
+### Download dashboards from web to solution-data using a Grafana admin API Key
 
 ```bash
 poetry run grafana-dashboard-manager \
     --host https://my.grafana.com \
-    --username admin --password mypassword \
+    --token admin_api_key \
+    download all \
+    --destination-dir /path/to/dashboards/
+```
+
+### Upload dashboards from solution-data to web using the Grafana admin user
+
+```bash
+poetry run grafana-dashboard-manager \
+    --host https://my.grafana.com \
+    --username admin_username --password admin_password \
     upload all \
     --source-dir /path/to/dashboards/
 ```
 
-N.B. if your Grafana is not at port 80/443 as indicated by the protocol prefix, the port needs to be specified as part of the `--host` argument, e.g. for a locally hosted instance on port 3000: `--host http://localhost:3000`
+### Upload dashboards from solution-data to web using a Grafana admin API Key
+
+```bash
+poetry run grafana-dashboard-manager \
+    --host https://my.grafana.com \
+    --token admin_api_key \
+    upload all \
+    --source-dir /path/to/dashboards/
+```
+
+**Please note:** if your Grafana is not hosted on port 80/443 as indicated by the protocol prefix, the port needs to be specified as part of the `--host` argument. For example, a locally hosted instance on port 3000: `--host http://localhost:3000`.
 
 ## Limitations
 
 - The home dashboard new deployment needs the default home dashboard to be manually set in the web UI, as the API to set the organisation default dashboard seems to be broken, at least on v8.2.3.
-
-- Currently expects a hardcoded 'home.json' dashboard to set as the home.
-
+- Currently expects a hardcoded `home.json` dashboard to set as the home.
 - Does not handle upload of dashboards more deeply nested than Grafana supports.
-
-- Does not support multi-organization deployments
+- Does not support multi-organization deployments.

--- a/grafana_dashboard_manager/api.py
+++ b/grafana_dashboard_manager/api.py
@@ -14,6 +14,7 @@ import logging
 from dataclasses import dataclass
 from typing import Dict
 
+import sys
 import requests
 import six
 
@@ -42,7 +43,7 @@ class RestApiBasicAuth:
     HTTP REST calls with status code checking and common auth/headers
     """
 
-    def __init__(self, host: str = "", credentials = None) -> None:
+    def __init__(self, host: str = "", credentials=None) -> None:
         self.host = host
         self.session = requests.Session()
         self.session.headers = {
@@ -87,7 +88,9 @@ class RestApiBasicAuth:
     def _check_response(status, response) -> Dict:
         """Gives just the response body if response is ok, otherwise fail hard"""
         if status != 200:
-            raise requests.HTTPError(f"{status}: {response}")
+            message = response["message"]
+            print(f"Request failed - 'HTTP error {status}: {message}'", file=sys.stderr)
+            quit(1)
 
         return response
 


### PR DESCRIPTION
## Motivation
- Following on from the merging of #7, I thought it was worthwhile to update the `README.md` content to mention this feature.
- I also found from my usage that the dump of a stack-trace on hitting a HTTP error was not useful. I have tidied this error up to be more legible.
## Changes
- Update documentation to mention `--token` flag.
- Tidy up `README.md` content generally.
- Stop HTTP errors from printing a stack-trace to terminal.
- Print a clear HTTP error code & message.