### PR TITLE
Fix error

### DIFF
--- a/grafana_dashboard_manager/dashboard.py
+++ b/grafana_dashboard_manager/dashboard.py
@@ -62,7 +62,7 @@ def update_dashlist_folder_ids(dashboard_definition: Dict) -> Dict:
             panel = update_single_dashlist_folder_id(panel)
     elif "rows" in dashboard_definition["dashboard"]:
         for row in dashboard_definition["dashboard"]["rows"]:
-            for panel in row:
+            for panel in row["panels"]:
                 panel = update_single_dashlist_folder_id(panel)
     else:
         title = dashboard_definition["dashboard"]["title"]
@@ -73,7 +73,6 @@ def update_dashlist_folder_ids(dashboard_definition: Dict) -> Dict:
 
 def update_single_dashlist_folder_id(panels_definition: Dict) -> Dict:
     if panels_definition["type"] == "dashlist":
-
         # Look up the target folder using the panel title - it needs to match!
         folder_name = panels_definition["title"]
         logger.info(f"Searching for folders with name {folder_name}")

--- a/grafana_dashboard_manager/dashboard.py
+++ b/grafana_dashboard_manager/dashboard.py
@@ -54,8 +54,23 @@ def update_dashlist_folder_ids(dashboard_definition: Dict) -> Dict:
     Checks consistency between the id of folders in the database with the dashlist panel definitions,
     updating if necessary.
     """
+
+    dashboard = dashboard_definition["dashboard"]
+
+    # Some dashboards use a list of "rows" with "panels" nested within, some dashboards just use "panels".
+    # If using "rows", we need to iterate over "rows" to extract all of the "panels"
+    if "panels" in dashboard:
+        panels_list = dashboard["panels"]
+    elif "rows" in dashboard:
+        rows_list = dashboard["rows"]
+        panels_list = []
+        for row in rows_list:
+            panels_list += row["panels"]
+    else:
+        logger.exception(f"❌ {dashboard['title']} does not have any any panels")
+
     # Look for panels of the 'dashlist' type
-    for panel in dashboard_definition["dashboard"]["panels"]:
+    for panel in panels_list:
         if panel["type"] == "dashlist":
 
             # Look up the target folder using the panel title - it needs to match!

--- a/grafana_dashboard_manager/dashboard.py
+++ b/grafana_dashboard_manager/dashboard.py
@@ -55,19 +55,17 @@ def update_dashlist_folder_ids(dashboard_definition: Dict) -> Dict:
     updating if necessary.
     """
 
-    dashboard = dashboard_definition["dashboard"]
-
     # Some dashboards use a list of "rows" with "panels" nested within, some dashboards just use "panels".
     # If using "rows", we need to iterate over "rows" to extract all of the "panels"
-    if "panels" in dashboard:
-        panels_list = dashboard["panels"]
-    elif "rows" in dashboard:
-        rows_list = dashboard["rows"]
+    if "panels" in dashboard_definition["dashboard"]:
+        panels_list = dashboard_definition["dashboard"]["panels"]
+    elif "rows" in dashboard_definition["dashboard"]:
         panels_list = []
-        for row in rows_list:
+        for row in dashboard_definition["dashboard"]["rows"]:
             panels_list += row["panels"]
     else:
-        logger.exception(f"❌ {dashboard['title']} does not have any any panels")
+        title = dashboard_definition["dashboard"]["title"]
+        logger.exception(f"❌ {title} does not have any any panels")
 
     # Look for panels of the 'dashlist' type
     for panel in panels_list:
@@ -93,6 +91,14 @@ def update_dashlist_folder_ids(dashboard_definition: Dict) -> Dict:
             else:
                 logger.info(f"Updating panel folderId option to {folder_id}")
                 panel["options"]["folderId"] = folder_id
+
+    # Reassign the panels list back to the actual 
+    if "panels" in dashboard_definition["dashboard"]:
+        dashboard_definition["dashboard"]["panels"] = panels_list
+    elif "rows" in dashboard_definition["dashboard"]:
+        for i, row in enumerate(dashboard_definition["dashboard"]["rows"]):
+            row["panels"] = panels_list[i]
+
     return dashboard_definition
 
 


### PR DESCRIPTION
## Why
Dashboards can organise panels into rows, which help to group and structure panels. The output JSON would therefore be structured as follows:

```json
{
  "rows": [
    {
      "panels": [{}]
    },
    {
      "panels": [{}]
    }
  ]
}
```

This was resulting in #3, as the program did not account for this edge case. This change resolves this.

## What
* The change extracts the inner loop logic of `update_dashlist_folder_ids` out into a function. 
* It introduces a conditional which checks if the dashboard actually has the `panels` attribute, if it has the `rows` attribute, or something else:
  * For the `panels` case, it uses a loop to call the function on each panel.
  * For the `rows` case, it uses a loop to cycle through each row, and then a nested loop to call the function on each panel.
  * For the something else, error.