### PR TITLE
Add setting home dashboard with API token auth

### DIFF
--- a/grafana_dashboard_manager/api.py
+++ b/grafana_dashboard_manager/api.py
@@ -53,8 +53,10 @@ class RestApiBasicAuth:
             pass
         elif isinstance(credentials, six.string_types):
             self.session.auth = TokenAuth(credentials)
+            self.isTokenAuth  = True
         else:
             self.session.auth = requests.auth.HTTPBasicAuth(*credentials)
+            self.isTokenAuth  = False
 
     def get(self, resource: str) -> Dict:
         """HTTP GET"""
@@ -75,7 +77,7 @@ class RestApiBasicAuth:
         response = self.session.request(
             "PUT",
             f"{self.host}/api/{resource}",
-            data=body
+            json=body
         )
         return self._check_response(response.status_code, json.loads(response.text))
 

--- a/grafana_dashboard_manager/dashboard_upload.py
+++ b/grafana_dashboard_manager/dashboard_upload.py
@@ -113,8 +113,6 @@ def create_update_dashboard(dashboard_file: Path, folder_uid: str):
 def set_home_dashboard():
     """
     Attempt to set a dashboard with uid 'home' as the default Home dashboard.
-    The /org/preferences API seems broken on v8.2.3, and setting homeDashboardId doesn't seem to take effect.
-    Leaving this here in case they fix this
     """
     logger.info("Setting home dashboard..")
     try:
@@ -126,9 +124,8 @@ def set_home_dashboard():
 
     # In the UI, only starred dashboards show up as able to set as home, which isn't actually required in theory, if
     # done through the API. But since the API doesn't work, star it to make the manual step a bit easier.
-    if not response["meta"].get("isStarred", False):
-        logger.info(grafana.api.post(f"user/stars/dashboard/{home_id}", {}))
-
-    # Seems homeDashboardId doesn't work. Interestingly theme and timezone does...
-    # body =  {'theme': 'dark', 'homeDashboardId': home_id, 'timezone': 'utc'}
-    # grafana.api.put("org/preferences", body)
+    if grafana.api.isTokenAuth is False:
+        if not response["meta"].get("isStarred", False):
+            logger.info(grafana.api.post(f"user/stars/dashboard/{home_id}", {}))
+    else:
+        logger.info(grafana.api.put("org/preferences", {'homeDashboardId': home_id}))


### PR DESCRIPTION
This solves #10 

There was a bug in grafana.api.put method: instead of JSON it was sending the request as application/x-www-form-urlencoded form data, so that's why it didn't work at all, basically resetting the home dashboard to 0.

Additionally I added Docker and Makefile and while at it I discovered that it doesn't build under Python 3.11, but didn't dig deeper into it.