### PR TITLE
feat : add option to upload without setting home

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ poetry run grafana-dashboard-manager \
 ## Limitations
 
 - The home dashboard new deployment needs the default home dashboard to be manually set in the web UI, as the API to set the organisation default dashboard seems to be broken, at least on v8.2.3.
-- Currently expects a hardcoded `home.json` dashboard to set as the home.
+- Currently expects a hardcoded home dashboard with `uid=home` to set as the home by default.
+Can be disabled with the option `--skip-home`.
 - Does not handle upload of dashboards more deeply nested than Grafana supports.
 - Does not support multi-organization deployments.

--- a/grafana_dashboard_manager/dashboard_upload.py
+++ b/grafana_dashboard_manager/dashboard_upload.py
@@ -19,6 +19,8 @@ import typer
 from rich.tree import Tree
 from requests import HTTPError
 
+from typing import Optional
+
 from .api import grafana
 from .dashboard import update_dashlist_folder_ids
 from .tree import walk_directory
@@ -39,7 +41,8 @@ def all(
         writable=True,
         readable=True,
         resolve_path=True,
-    )
+    ),
+    skip_home: Optional[bool] = False,
 ):  # pylint: disable=redefined-builtin
     """
     Download folder-structured dashboards and write to json files at the destination_root path
@@ -61,8 +64,9 @@ def all(
 
                 create_update_dashboard(dashboard_file, folder_uid)
 
-    # Set home dashboard
-    set_home_dashboard()
+    if not skip_home:
+        # Set home dashboard
+        set_home_dashboard()
     logger.info("✅")
 
 


### PR DESCRIPTION
Hi,
Thanks for sharing this CLI.

I'd like to add a simple option : I do not want to use a home dashboard.
This is why there is now a skip-home option in dashboard_upload.

Regards
