### PR TITLE
Fix remove version and handle slash in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ poetry run grafana-dashboard-manager \
 ## Limitations
 
 - The home dashboard new deployment needs the default home dashboard to be manually set in the web UI, as the API to set the organisation default dashboard seems to be broken, at least on v8.2.3.
-- Currently expects a hardcoded `home.json` dashboard to set as the home.
+- Currently expects a hardcoded home dashboard with `uid=home` to set as the home by default.
+can be disabled with the option `skip-home`.
 - Does not handle upload of dashboards more deeply nested than Grafana supports.
 - Does not support multi-organization deployments.

--- a/README.md
+++ b/README.md
@@ -97,3 +97,5 @@ poetry run grafana-dashboard-manager \
 can be disabled with the option `skip-home`.
 - Does not handle upload of dashboards more deeply nested than Grafana supports.
 - Does not support multi-organization deployments.
+- The `version` of the dashboard is removed of the json files in order to avoid unneeded diff in git of identical dashboards with diferent versions.
+- The "/" in the title of the dashboard are now supported.

--- a/grafana_dashboard_manager/dashboard.py
+++ b/grafana_dashboard_manager/dashboard.py
@@ -98,6 +98,14 @@ def update_single_dashlist_folder_id(panels_definition: Dict) -> Dict:
     return panels_definition
 
 
+def remove_version(dashboard_definition: Dict) -> Dict:
+    """
+    Remove version of dashboard.
+    """
+    dashboard_definition["dashboard"].pop("version")
+    return dashboard_definition
+
+
 def _get_all_dashboard_uids() -> List[str]:
     response = grafana.api.get("search?query=%")
     return [db["uid"] for db in response]

--- a/grafana_dashboard_manager/dashboard_download.py
+++ b/grafana_dashboard_manager/dashboard_download.py
@@ -83,6 +83,8 @@ def _write_dashboards_to_local_folder_from_grafana_folder(folder: Dict, destinat
 
             # Update references in dashboard pickers to folder ids, as they are auto generated
             dashboard_definition = update_dashlist_folder_ids(dashboard_definition)
+            # remove dashboard version
+            remove_version(dashboard_definition)
 
             # Write it to file
             dashboard_file: Path = (


### PR DESCRIPTION
This evolution contains 2 features : 
- it remove the grafana version from the json file written to disks whel downloading all dashboards
- it fix a bug where dashboard that contain a "/" in their title are currently ignored.